### PR TITLE
Bump dependencies upper bounds

### DIFF
--- a/snap-cors.cabal
+++ b/snap-cors.cabal
@@ -35,7 +35,7 @@ library
     attoparsec >= 0.10 && <0.12,
     base >= 4.5 && < 5,
     bytestring >= 0.10 && < 0.11,
-    case-insensitive >= 1.0 && <1.1,
+    case-insensitive >= 1.0 && <1.2,
     hashable >= 1.1 && <1.3,
     network >= 2.4 && < 2.5,
     snap >= 0.13 && < 0.14,


### PR DESCRIPTION
This built just fine on my computer, but I wouldn't know if `snap-cors` continues to behave as expected. 
