### PR TITLE
Add GHC 7.10 Compatability

### DIFF
--- a/src/Snap/CORS.hs
+++ b/src/Snap/CORS.hs
@@ -205,7 +205,7 @@ applyCORS options m =
 
   splitHeaders =
     let spaces = Attoparsec.many' Attoparsec.space
-        headerC = Attoparsec.satisfy (not . (`elem` " ,"))
+        headerC = Attoparsec.satisfy (not . (`elem`( " ," :: String)))
         headerName = Attoparsec.many' headerC
         header = spaces *> headerName <* spaces
         parser = HashSet.fromList <$> header `Attoparsec.sepBy` (Attoparsec.char ',')


### PR DESCRIPTION
`snap-cors` doesn't build on GHC 7.10 because of a small bug caused by the FTP proposal. Adding `:: String` to the `elem` call fixes the issue (via: [GHC 7.10 Migration Guide](https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10))