### PR TITLE
Narrow deps to snap-core, plus readme for snaplets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+snap-cors
+=========
+
+Add CORS (cross-origin resource sharing) headers to Snap
+applications. This enables web applications running on other domains
+to make requests against another application.
+
+Snaplet wrapper
+===============
+
+Making a snaplet wrapper for CORS is easy, simply use 'wrapSite':
+
+```haskell
+import qualified Snap
+
+...
+   Snap.wrapSite $ applyCORS defaultOptions
+...
+```

--- a/snap-cors.cabal
+++ b/snap-cors.cabal
@@ -41,7 +41,7 @@ library
     bytestring >= 0.10 && < 0.11,
     case-insensitive >= 1.0 && <1.3,
     hashable >= 1.1 && <1.3,
-    snap >= 0.13 && < 0.15,
+    snap-core >= 0.9 && <0.11,
     text >= 0.11 && < 1.3,
     transformers >= 0.3 && < 0.5,
     unordered-containers >= 0.2 && <0.3

--- a/src/Snap/CORS.hs
+++ b/src/Snap/CORS.hs
@@ -4,12 +4,9 @@
 -- or unconditionally to the entire site, or you can apply CORS headers to a
 -- single route.
 module Snap.CORS
-  ( -- * Wrappers
-    wrapCORS
-  , wrapCORSWithOptions
-
-  -- * Applying CORS to a specific response
-  , applyCORS
+  (
+    -- * Applying CORS to a specific response
+    applyCORS
 
     -- * Option Specification
   , CORSOptions(..)
@@ -37,7 +34,7 @@ import qualified Data.ByteString.Char8 as Char8
 import qualified Data.CaseInsensitive as CI
 import qualified Data.HashSet as HashSet
 import qualified Data.Text as Text
-import qualified Snap
+import qualified Snap.Core as Snap
 
 -- | A set of origins. RFC 6454 specifies that origins are a scheme, host and
 -- port, so the 'OriginSet' wrapper around a 'HashSet.HashSet' ensures that each
@@ -98,15 +95,6 @@ defaultOptions = CORSOptions
   , corsAllowedHeaders = return
   }
 
--- | Apply CORS for every request, unconditionally.
---
--- 'wrapCors' ≡ 'wrapCORSWithOptions' 'defaultOptions'
-wrapCORS :: Snap.Initializer b v ()
-wrapCORS = wrapCORSWithOptions defaultOptions
-
--- | Initialize CORS for all requests with specific options.
-wrapCORSWithOptions :: CORSOptions (Snap.Handler b v) -> Snap.Initializer b v ()
-wrapCORSWithOptions options = Snap.wrapSite (applyCORS options)
 
 -- | Apply CORS headers to a specific request. This is useful if you only have
 -- a single action that needs CORS headers, and you don't want to pay for


### PR DESCRIPTION
Hi! This drops the full 'snap' dependency in favor of a more minimal 'snap-core' dep, the snap framework brings in a huge amount of bloat for those of us doing simpler servers that nonetheless need CORS support. Given that snaplet support comes down to issuing "wrapSite" it seems like an unobtrusive change, and I've made a README to document this. Thanks! Stuart
